### PR TITLE
fix: the ocr plugin contains a hardcoded api key 'k8... in ocr.js

### DIFF
--- a/plugins/ocr.js
+++ b/plugins/ocr.js
@@ -17,8 +17,9 @@ module.exports = {
 
       const buffer = await m.quoted.download()
 
+      if (!process.env.OCR_API_KEY) return m.reply('OCR API key is not configured.')
       const form = new FormData()
-      form.append('apikey', process.env.OCR_API_KEY || 'K81241004488957')
+      form.append('apikey', process.env.OCR_API_KEY)
       form.append('language', 'eng')
       form.append('isOverlayRequired', 'false')
       form.append('file', buffer, {


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `plugins/ocr.js`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `plugins/ocr.js:21` |
| **Assessment** | Likely exploitable |
| **Chain Complexity** | 2-step |

**Description**: The OCR plugin contains a hardcoded API key 'K81241004488957' as a fallback value when the OCR_API_KEY environment variable is not set. This key is exposed in the source code and can be discovered through repository access, code review, or reverse engineering.

## Evidence

**Exploitation scenario**: An attacker obtains the source code and extracts the hardcoded API key.

**Scanner confirmation**: multi_agent_ai rule `V-001` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This is a web service - vulnerabilities in request handlers are directly exploitable by remote attackers.

## Changes
- `plugins/ocr.js`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
